### PR TITLE
Handle incompatible checkpoints gracefully

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,15 +1,145 @@
 import os
-import torch
 import random
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
 import numpy as np
-from collections import deque
+import torch
+
 from game import SnakeGameAI, Direction, Point
-from model import Linear_QNet, QTrainer
 from helper import plot
+from model import DuelingQNet, QTrainer
 
 MAX_MEMORY = 100_000
-BATCH_SIZE = 1000
-LR = 0.001
+BATCH_SIZE = 512
+LR = 0.0005
+PRIORITIZED_ALPHA = 0.6
+PRIORITIZED_BETA_START = 0.4
+BETA_FRAMES = 100_000
+PRIORITY_EPS = 1e-5
+
+
+@dataclass
+class Transition:
+    state: np.ndarray
+    action: int
+    reward: float
+    next_state: np.ndarray
+    done: bool
+
+
+class PrioritizedReplayBuffer:
+    def __init__(self, capacity: int, alpha: float):
+        self.capacity = capacity
+        self.alpha = alpha
+        self.buffer: List[Transition] = []
+        self.priorities = np.zeros((capacity,), dtype=np.float32)
+        self.pos = 0
+        self.max_priority = 1.0
+
+    def __len__(self) -> int:
+        return len(self.buffer)
+
+    def add(self, state, action, reward, next_state, done):
+        transition = Transition(
+            state=np.array(state, dtype=np.float32),
+            action=int(action),
+            reward=float(reward),
+            next_state=np.array(next_state, dtype=np.float32),
+            done=bool(done),
+        )
+
+        if len(self.buffer) < self.capacity:
+            self.buffer.append(transition)
+        else:
+            self.buffer[self.pos] = transition
+
+        self.priorities[self.pos] = self.max_priority
+        self.pos = (self.pos + 1) % self.capacity
+
+    def _get_probabilities(self) -> np.ndarray:
+        if len(self.buffer) == self.capacity:
+            priorities = self.priorities
+        else:
+            priorities = self.priorities[: len(self.buffer)]
+        scaled_priorities = priorities ** self.alpha
+        total = scaled_priorities.sum()
+        if total == 0:
+            return np.ones_like(scaled_priorities) / len(scaled_priorities)
+        return scaled_priorities / total
+
+    def _stratified_indices(self, probabilities: np.ndarray, batch_size: int) -> np.ndarray:
+        cumulative = np.cumsum(probabilities)
+        cumulative[-1] = 1.0
+        positions = (np.arange(batch_size) + np.random.random(batch_size)) / batch_size
+        return np.searchsorted(cumulative, positions)
+
+    def sample(self, batch_size: int, beta: float):
+        if len(self.buffer) == 0:
+            raise ValueError("Cannot sample from an empty replay buffer")
+
+        actual_batch = min(batch_size, len(self.buffer))
+        probabilities = self._get_probabilities()
+        indices = self._stratified_indices(probabilities, actual_batch)
+        samples = [self.buffer[idx] for idx in indices]
+
+        states = np.stack([t.state for t in samples])
+        actions = np.array([t.action for t in samples], dtype=np.int64)
+        rewards = np.array([t.reward for t in samples], dtype=np.float32)
+        next_states = np.stack([t.next_state for t in samples])
+        dones = np.array([t.done for t in samples], dtype=np.float32)
+
+        weights = (len(self.buffer) * probabilities[indices]) ** (-beta)
+        weights /= weights.max()
+
+        return states, actions, rewards, next_states, dones, indices, weights
+
+    def update_priorities(self, indices, td_errors):
+        td_errors = np.abs(td_errors) + PRIORITY_EPS
+        for idx, error in zip(indices, td_errors):
+            self.priorities[idx] = error
+        self.max_priority = max(self.max_priority, td_errors.max())
+
+    def to_serializable(self) -> Dict[str, Any]:
+        return {
+            'buffer': [
+                {
+                    'state': transition.state.tolist(),
+                    'action': transition.action,
+                    'reward': transition.reward,
+                    'next_state': transition.next_state.tolist(),
+                    'done': transition.done,
+                }
+                for transition in self.buffer
+            ],
+            'priorities': self.priorities[: len(self.buffer)].tolist(),
+            'pos': self.pos,
+            'max_priority': self.max_priority,
+        }
+
+    def load_serializable(self, data: Dict[str, Any]) -> None:
+        buffer_data = data.get('buffer', [])
+        self.buffer = [
+            Transition(
+                state=np.array(item['state'], dtype=np.float32),
+                action=int(item['action']),
+                reward=float(item['reward']),
+                next_state=np.array(item['next_state'], dtype=np.float32),
+                done=bool(item['done']),
+            )
+            for item in buffer_data
+        ]
+
+        self.priorities = np.zeros((self.capacity,), dtype=np.float32)
+        priorities = data.get('priorities', [])
+        priority_array = np.array(priorities, dtype=np.float32)
+        length = min(len(priority_array), len(self.buffer))
+        if length:
+            self.priorities[:length] = priority_array[:length]
+        self.max_priority = max(float(data.get('max_priority', 1.0)), PRIORITY_EPS)
+        if len(self.buffer) > length:
+            self.priorities[length: len(self.buffer)] = self.max_priority
+        self.pos = data.get('pos', len(self.buffer) % self.capacity)
 
 
 class Agent:
@@ -18,9 +148,18 @@ class Agent:
         self.n_games = 0
         self.epsilon = 0  # randomness
         self.gamma = 0.9  # discount rate
-        self.memory = deque(maxlen=MAX_MEMORY)  # popleft()
-        self.model = Linear_QNet(11, 256, 3)
-        self.trainer = QTrainer(self.model, lr=LR, gamma=self.gamma)
+        self.frame_count = 0
+        self.memory = PrioritizedReplayBuffer(MAX_MEMORY, PRIORITIZED_ALPHA)
+        self.model = DuelingQNet(11, [512, 512, 256], 3)
+        self.target_model = DuelingQNet(11, [512, 512, 256], 3)
+        self.trainer = QTrainer(
+            self.model,
+            self.target_model,
+            lr=LR,
+            gamma=self.gamma,
+            target_update_tau=0.01,
+            target_update_interval=1,
+        )
         self.record = 0
         self.total_score = 0
         self.plot_scores = []
@@ -33,35 +172,70 @@ class Agent:
             return
 
         checkpoint = torch.load(self.checkpoint_path, map_location=torch.device('cpu'))
+
+        def _load_state(module: torch.nn.Module, state_dict: Dict[str, torch.Tensor], name: str) -> bool:
+            if not state_dict:
+                return False
+            current_state = module.state_dict()
+            compatible_state = {}
+            for key, value in state_dict.items():
+                if key in current_state and current_state[key].shape == value.shape:
+                    compatible_state[key] = value
+            if not compatible_state:
+                print(f"Skipping incompatible {name} checkpoint (architecture mismatch)")
+                return False
+            missing = set(current_state.keys()) - set(compatible_state.keys())
+            unexpected = set(state_dict.keys()) - set(compatible_state.keys())
+            if missing or unexpected:
+                print(
+                    f"Partially loaded {name} checkpoint: "
+                    f"skipped {len(missing)} missing and {len(unexpected)} unexpected parameters"
+                )
+            module.load_state_dict({**current_state, **compatible_state})
+            return True
+
         model_state = checkpoint.get('model_state')
-        if model_state is not None:
-            self.model.load_state_dict(model_state)
+        model_loaded = _load_state(self.model, model_state or {}, 'model')
+        if model_loaded:
+            self.target_model.load_state_dict(self.model.state_dict())
+
+        target_state = checkpoint.get('target_model_state')
+        _load_state(self.target_model, target_state or {}, 'target model')
         optimizer_state = checkpoint.get('optimizer_state')
         if optimizer_state is not None:
             self.trainer.optimizer.load_state_dict(optimizer_state)
 
         memory = checkpoint.get('memory')
-        if memory is not None:
-            self.memory = deque(memory, maxlen=MAX_MEMORY)
+        if memory:
+            if isinstance(memory, dict):
+                self.memory.load_serializable(memory)
+            else:
+                for item in memory:
+                    state, action, reward, next_state, done = item
+                    action_idx = int(np.argmax(action)) if isinstance(action, (list, tuple, np.ndarray)) else int(action)
+                    self.memory.add(state, action_idx, reward, next_state, done)
 
         self.n_games = checkpoint.get('n_games', self.n_games)
         self.record = checkpoint.get('record', self.record)
         self.total_score = checkpoint.get('total_score', self.total_score)
         self.plot_scores = checkpoint.get('plot_scores', self.plot_scores)
         self.plot_mean_scores = checkpoint.get('plot_mean_scores', self.plot_mean_scores)
+        self.frame_count = checkpoint.get('frame_count', self.frame_count)
 
         print(f"Loaded checkpoint with {self.n_games} games played and record {self.record}")
 
     def save_checkpoint(self):
         checkpoint = {
             'model_state': self.model.state_dict(),
+            'target_model_state': self.target_model.state_dict(),
             'optimizer_state': self.trainer.optimizer.state_dict(),
-            'memory': list(self.memory),
+            'memory': self.memory.to_serializable(),
             'n_games': self.n_games,
             'record': self.record,
             'total_score': self.total_score,
             'plot_scores': self.plot_scores,
             'plot_mean_scores': self.plot_mean_scores,
+            'frame_count': self.frame_count,
         }
 
         checkpoint_dir = os.path.dirname(self.checkpoint_path)
@@ -117,21 +291,27 @@ class Agent:
         return np.array(state, dtype=int)
 
     def remember(self, state, action, reward, next_state, done):
-        self.memory.append((state, action, reward, next_state, done))  # popleft if MAX_MEMORY is reached
+        action_idx = int(np.argmax(action))
+        self.memory.add(state, action_idx, reward, next_state, done)
 
     def train_long_memory(self):
-        if len(self.memory) > BATCH_SIZE:
-            mini_sample = random.sample(self.memory, BATCH_SIZE)  # list of tuples
-        else:
-            mini_sample = self.memory
+        if len(self.memory) == 0:
+            return
 
-        states, actions, rewards, next_states, dones = zip(*mini_sample)
-        self.trainer.train_step(states, actions, rewards, next_states, dones)
-        # for state, action, reward, nexrt_state, done in mini_sample:
-        #    self.trainer.train_step(state, action, reward, next_state, done)
+        beta = min(1.0, PRIORITIZED_BETA_START + self.frame_count * (1.0 - PRIORITIZED_BETA_START) / BETA_FRAMES)
+        states, actions, rewards, next_states, dones, indices, weights = self.memory.sample(BATCH_SIZE, beta)
+        td_errors = self.trainer.train_step(states, actions, rewards, next_states, dones, weights=weights)
+        self.memory.update_priorities(indices, td_errors)
 
     def train_short_memory(self, state, action, reward, next_state, done):
-        self.trainer.train_step(state, action, reward, next_state, done)
+        action_idx = int(np.argmax(action))
+        self.trainer.train_step(
+            np.expand_dims(np.asarray(state, dtype=np.float32), axis=0),
+            np.array([action_idx], dtype=np.int64),
+            np.array([reward], dtype=np.float32),
+            np.expand_dims(np.asarray(next_state, dtype=np.float32), axis=0),
+            np.array([done], dtype=np.float32),
+        )
 
     def get_action(self, state):
         # random moves: tradeoff exploration / exploitation
@@ -141,8 +321,8 @@ class Agent:
             move = random.randint(0, 2)
             final_move[move] = 1
         else:
-            state0 = torch.tensor(state, dtype=torch.float)
-            prediction = self.model(state0)
+            state0 = torch.tensor(state, dtype=torch.float32).unsqueeze(0)
+            prediction = self.model(state0)[0]
             move = torch.argmax(prediction).item()
             final_move[move] = 1
 
@@ -166,6 +346,7 @@ def train():
         # perform move and get new state
         reward, done, score = game.play_step(final_move)
         state_new = agent.get_state(game)
+        agent.frame_count += 1
 
         # train short memory
         agent.train_short_memory(state_old, final_move, reward, state_new, done)

--- a/model.py
+++ b/model.py
@@ -1,22 +1,70 @@
+import os
+from typing import Iterable, Optional
+
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import torch.nn.functional as F
-import os
 
 
 class Linear_QNet(nn.Module):
-    def __init__(self, input_size, hidden_size, output_size):
+    """Legacy two-layer MLP network retained for backwards compatibility."""
+
+    def __init__(self, input_size: int, hidden_size: int, output_size: int):
         super().__init__()
         self.linear1 = nn.Linear(input_size, hidden_size)
         self.linear2 = nn.Linear(hidden_size, output_size)
 
-    def forward(self, x):
-        x = F.relu(self.linear1(x))
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.relu(self.linear1(x))
         x = self.linear2(x)
         return x
 
-    def save(self, file_name='model.pth'):
+    def save(self, file_name: str = 'model.pth') -> None:
+        model_folder_path = './model'
+        if not os.path.exists(model_folder_path):
+            os.makedirs(model_folder_path)
+
+        file_name = os.path.join(model_folder_path, file_name)
+        torch.save(self.state_dict(), file_name)
+
+
+class DuelingQNet(nn.Module):
+    """Deeper dueling network that learns separate value and advantage streams."""
+
+    def __init__(self, input_size: int, hidden_sizes: Iterable[int], output_size: int):
+        super().__init__()
+        hidden_sizes = list(hidden_sizes)
+        if not hidden_sizes:
+            raise ValueError("hidden_sizes must contain at least one element")
+
+        layers = []
+        in_features = input_size
+        for hidden_size in hidden_sizes:
+            layers.append(nn.Linear(in_features, hidden_size))
+            layers.append(nn.ReLU())
+            in_features = hidden_size
+
+        self.feature_layer = nn.Sequential(*layers)
+        last_hidden = hidden_sizes[-1]
+        self.value_stream = nn.Sequential(
+            nn.Linear(last_hidden, last_hidden),
+            nn.ReLU(),
+            nn.Linear(last_hidden, 1),
+        )
+        self.advantage_stream = nn.Sequential(
+            nn.Linear(last_hidden, last_hidden),
+            nn.ReLU(),
+            nn.Linear(last_hidden, output_size),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        features = self.feature_layer(x)
+        values = self.value_stream(features)
+        advantages = self.advantage_stream(features)
+        q_values = values + advantages - advantages.mean(dim=1, keepdim=True)
+        return q_values
+
+    def save(self, file_name: str = 'model.pth') -> None:
         model_folder_path = './model'
         if not os.path.exists(model_folder_path):
             os.makedirs(model_folder_path)
@@ -26,47 +74,81 @@ class Linear_QNet(nn.Module):
 
 
 class QTrainer:
-    def __init__(self, model, lr, gamma):
+    def __init__(
+        self,
+        model: nn.Module,
+        target_model: nn.Module,
+        lr: float,
+        gamma: float,
+        target_update_tau: float = 0.005,
+        target_update_interval: int = 1,
+        max_grad_norm: Optional[float] = 10.0,
+    ):
         self.lr = lr
         self.gamma = gamma
         self.model = model
+        self.target_model = target_model
         self.optimizer = optim.Adam(model.parameters(), lr=self.lr)
-        self.criterion = nn.MSELoss()
+        self.target_update_tau = target_update_tau
+        self.target_update_interval = target_update_interval
+        self.max_grad_norm = max_grad_norm
+        self._updates = 0
 
-    def train_step(self, state, action, reward, next_state, done):
-        state = torch.tensor(state, dtype=torch.float)
-        next_state = torch.tensor(next_state, dtype=torch.float)
+        # Ensure the target network starts as an exact copy of the policy network.
+        self.target_model.load_state_dict(self.model.state_dict())
+        for param in self.target_model.parameters():
+            param.requires_grad = False
+
+    def _soft_update_target(self) -> None:
+        tau = self.target_update_tau
+        with torch.no_grad():
+            for target_param, param in zip(self.target_model.parameters(), self.model.parameters()):
+                target_param.data.copy_(tau * param.data + (1.0 - tau) * target_param.data)
+
+    def train_step(
+        self,
+        state,
+        action,
+        reward,
+        next_state,
+        done,
+        weights=None,
+    ):
+        state = torch.tensor(state, dtype=torch.float32)
+        next_state = torch.tensor(next_state, dtype=torch.float32)
         action = torch.tensor(action, dtype=torch.long)
-        reward = torch.tensor(reward, dtype=torch.float)
-        # (n, x)
+        reward = torch.tensor(reward, dtype=torch.float32)
+        done = torch.tensor(done, dtype=torch.float32)
 
-        if len(state.shape) == 1:
-            # (1, x)
-            state = torch.unsqueeze(state, 0)
-            next_state = torch.unsqueeze(next_state, 0)
-            action = torch.unsqueeze(action, 0)
-            reward = torch.unsqueeze(reward, 0)
-            done = (done,)
+        if weights is None:
+            weights_tensor = torch.ones_like(reward)
+        else:
+            weights_tensor = torch.tensor(weights, dtype=torch.float32)
 
-        # 1: predicted Q values with current state
-        pred = self.model(state)
+        q_values = self.model(state)
+        current_q = q_values.gather(1, action.unsqueeze(-1)).squeeze(-1)
 
-        target = pred.clone()
-        for idx in range(len(done)):
-            Q_new = reward[idx]
-            if not done[idx]:
-                Q_new = reward[idx] + self.gamma * torch.max(self.model(next_state[idx]))
+        with torch.no_grad():
+            next_actions = self.model(next_state).argmax(dim=1, keepdim=True)
+            next_q = self.target_model(next_state).gather(1, next_actions).squeeze(-1)
+            target_q = reward + self.gamma * next_q * (1 - done)
 
-            target[idx][torch.argmax(action[idx]).item()] = Q_new
+        td_errors = target_q - current_q
+        loss = (weights_tensor * td_errors.pow(2)).mean()
 
-        # 2: Q_new = r + y * max(next_predicted Q value) -> only do this if not done
-        # pred.clone()
-        # preds[argmax(action)] = Q_new
         self.optimizer.zero_grad()
-        loss = self.criterion(target, pred)
         loss.backward()
 
+        if self.max_grad_norm is not None:
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)
+
         self.optimizer.step()
+
+        self._updates += 1
+        if self._updates % self.target_update_interval == 0:
+            self._soft_update_target()
+
+        return td_errors.detach().cpu().numpy()
 
 
 


### PR DESCRIPTION
## Summary
- guard checkpoint restoration to skip weights that do not match the current network architecture
- ensure target network mirrors any successfully restored model weights and leave incompatible checkpoints untouched

## Testing
- python -m compileall agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d510e758c0832fb3a70c7c5b142032